### PR TITLE
エラーを日本語化する機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,3 +74,5 @@ gem 'image_processing', '~> 1.2'
 gem 'active_hash'
 
 gem 'payjp'
+
+gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,6 +173,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails-i18n (6.0.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 7)
     rails_12factor (0.0.3)
       rails_serve_static_assets
       rails_stdout_logging
@@ -311,6 +314,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 6.0.0)
+  rails-i18n
   rails_12factor
   rspec-rails (~> 4.0.0)
   rubocop

--- a/config/application.rb
+++ b/config/application.rb
@@ -2,18 +2,12 @@ require_relative 'boot'
 
 require 'rails/all'
 
-# Require the gems listed in Gemfile, including any gems
-# you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
 module Furima31649
   class Application < Rails::Application
-    # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 
-    # Settings in config/environments/* take precedence over those specified here.
-    # Application configuration can go into files in config/initializers
-    # -- all .rb files in that directory are automatically loaded after loading
-    # the framework and any gems in your application.
+    config.i18n.default_locale = :ja
   end
 end

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,143 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        email: Eメール
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password: パスワード
+        password_confirmation: パスワード（確認用）
+        remember_created_at: ログイン記憶時刻
+        remember_me: ログインを記憶する
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認Eメール
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
+    models:
+      user: ユーザ
+  devise:
+    confirmations:
+      confirmed: メールアドレスが確認できました。
+      new:
+        resend_confirmation_instructions: アカウント確認メール再送
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      last_attempt: もう一回誤るとアカウントがロックされます。
+      locked: アカウントは凍結されています。
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: アカウント登録もしくはログインしてください。
+      unconfirmed: メールアドレスの本人確認が必要です。
+    mailer:
+      confirmation_instructions:
+        action: メールアドレスの確認
+        greeting: "%{recipient}様"
+        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
+        subject: メールアドレス確認メール
+      email_changed:
+        greeting: こんにちは、%{recipient}様。
+        message: あなたのメール変更（%{email}）のお知らせいたします。
+        message_unconfirmed: 
+        subject: メール変更完了。
+      password_change:
+        greeting: "%{recipient}様"
+        message: パスワードが再設定されたことを通知します。
+        subject: パスワードの変更について
+      reset_password_instructions:
+        action: パスワード変更
+        greeting: "%{recipient}様"
+        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
+        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        subject: パスワードの再設定について
+      unlock_instructions:
+        action: アカウントのロック解除
+        greeting: "%{recipient}様"
+        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
+        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
+        subject: アカウントの凍結解除について
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      edit:
+        change_my_password: パスワードを変更する
+        change_your_password: パスワードを変更
+        confirm_new_password: 確認用新しいパスワード
+        new_password: 新しいパスワード
+      new:
+        forgot_your_password: パスワードを忘れましたか?
+        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
+      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
+      updated: パスワードが正しく変更されました。
+      updated_not_active: パスワードが正しく変更されました。
+    registrations:
+      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      edit:
+        are_you_sure: 本当によろしいですか?
+        cancel_my_account: アカウント削除
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        title: "%{resource}編集"
+        unhappy: 気に入りません
+        update: 更新
+        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+      new:
+        sign_up: アカウント登録
+      signed_up: アカウント登録が完了しました。
+      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
+      signed_up_but_locked: アカウントが凍結されているためログインできません。
+      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
+      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
+      updated: アカウント情報を変更しました。
+      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+    sessions:
+      already_signed_out: 既にログアウト済みです。
+      new:
+        sign_in: ログイン
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+    shared:
+      links:
+        back: 戻る
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか?
+        didn_t_receive_unlock_instructions: アカウントの凍結解除方法のメールを受け取っていませんか?
+        forgot_your_password: パスワードを忘れましたか?
+        sign_in: ログイン
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: アカウント登録
+      minimum_password_length: "（%{count}字以上）"
+    unlocks:
+      new:
+        resend_unlock_instructions: アカウントの凍結解除方法を再送する
+      send_instructions: アカウントの凍結解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントの凍結解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントを凍結解除しました。
+  errors:
+    messages:
+      already_confirmed: は既に登録済みです。ログインしてください。
+      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
+      expired: の有効期限が切れました。新しくリクエストしてください。
+      not_found: は見つかりませんでした。
+      not_locked: は凍結されていません。
+      not_saved:
+        one: エラーが発生したため %{resource} は保存されませんでした。
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,32 @@
+ja:
+ activerecord:
+   attributes:
+    user: 
+      nickname: ニックネーム
+      email: メールアドレス
+      last_name: 姓
+      first_name: 名
+      last_reading: 姓のカタカナ
+      first_reading: 名のカタカナ
+      birthday: 誕生日
+    item: 
+      name: 商品名
+      explain: 商品の説明
+      price: 商品の販売価格
+      image: 商品の画像  
+      category_id: カテゴリー
+      status_id: 商品の状態
+      delivery_fee_id: 配送料の負担
+      prefecture_id: 発送元の地域
+      day_id: 発送までの日数
+ activemodel:
+   attributes:
+    item_purchase: 
+      token: カード情報、有効期限、セキュリティコード
+      postal_code: 郵便番号
+      prefecture_id: 都道府県
+      city: 市区町村
+      house_number: 番地
+      phone_number: 電話番号
+      building: 建物名
+      

--- a/spec/models/item_purchase_spec.rb
+++ b/spec/models/item_purchase_spec.rb
@@ -20,47 +20,47 @@ RSpec.describe ItemPurchase, type: :model do
       it 'tokenが空だと登録できない' do
         @item_purchase.token = nil
         @item_purchase.valid?
-        expect(@item_purchase.errors.full_messages).to include("Token can't be blank")
+        expect(@item_purchase.errors.full_messages).to include("Tokenを入力してください")
       end
       it 'postal_codeが空だと登録できない' do
         @item_purchase.postal_code = nil
         @item_purchase.valid?
-        expect(@item_purchase.errors.full_messages).to include("Postal code can't be blank")
+        expect(@item_purchase.errors.full_messages).to include("Postal codeを入力してください")
       end
       it 'postal_codeが半角のハイフンを含んだ形式でないと保存できないこと' do
         @item_purchase.postal_code = '1234567'
         @item_purchase.valid?
-        expect(@item_purchase.errors.full_messages).to include("Postal code が間違っています (-)が必要です")
+        expect(@item_purchase.errors.full_messages).to include("Postal codeが間違っています (-)が必要です")
       end
       it 'prefecture_idが空だと登録できない' do
         @item_purchase.prefecture_id = nil
         @item_purchase.valid?
-        expect(@item_purchase.errors.full_messages).to include("Prefecture can't be blank")
+        expect(@item_purchase.errors.full_messages).to include("Prefectureを入力してください")
       end
       it 'prefecture_idが1だと登録できない' do
         @item_purchase.prefecture_id = 1
         @item_purchase.valid?
-        expect(@item_purchase.errors.full_messages).to include("Prefecture must be other than 1")
+        expect(@item_purchase.errors.full_messages).to include("Prefectureは1以外の値にしてください")
       end
       it 'cityが空だと登録できない' do
         @item_purchase.city = nil
         @item_purchase.valid?
-        expect(@item_purchase.errors.full_messages).to include("City can't be blank")
+        expect(@item_purchase.errors.full_messages).to include("Cityを入力してください")
       end
       it 'house_numberが空だと登録できない' do
         @item_purchase.house_number = nil
         @item_purchase.valid?
-        expect(@item_purchase.errors.full_messages).to include("House number can't be blank")
+        expect(@item_purchase.errors.full_messages).to include("House numberを入力してください")
       end
       it 'phone_numberが空だと登録できない' do
         @item_purchase.phone_number = nil
         @item_purchase.valid?
-        expect(@item_purchase.errors.full_messages).to include("Phone number can't be blank")
+        expect(@item_purchase.errors.full_messages).to include("Phone numberを入力してください")
       end
       it 'phone_numberが12桁だと登録できない' do
         @item_purchase.phone_number = 123456789123
         @item_purchase.valid?
-        expect(@item_purchase.errors.full_messages).to include("Phone number が間違っています")
+        expect(@item_purchase.errors.full_messages).to include("Phone numberが間違っています")
       end
     end
 

--- a/spec/models/item_purchase_spec.rb
+++ b/spec/models/item_purchase_spec.rb
@@ -20,47 +20,47 @@ RSpec.describe ItemPurchase, type: :model do
       it 'tokenが空だと登録できない' do
         @item_purchase.token = nil
         @item_purchase.valid?
-        expect(@item_purchase.errors.full_messages).to include("Tokenを入力してください")
+        expect(@item_purchase.errors.full_messages).to include("カード情報、有効期限、セキュリティコードを入力してください")
       end
       it 'postal_codeが空だと登録できない' do
         @item_purchase.postal_code = nil
         @item_purchase.valid?
-        expect(@item_purchase.errors.full_messages).to include("Postal codeを入力してください")
+        expect(@item_purchase.errors.full_messages).to include("郵便番号を入力してください")
       end
       it 'postal_codeが半角のハイフンを含んだ形式でないと保存できないこと' do
         @item_purchase.postal_code = '1234567'
         @item_purchase.valid?
-        expect(@item_purchase.errors.full_messages).to include("Postal codeが間違っています (-)が必要です")
+        expect(@item_purchase.errors.full_messages).to include("郵便番号が間違っています (-)が必要です")
       end
       it 'prefecture_idが空だと登録できない' do
         @item_purchase.prefecture_id = nil
         @item_purchase.valid?
-        expect(@item_purchase.errors.full_messages).to include("Prefectureを入力してください")
+        expect(@item_purchase.errors.full_messages).to include("都道府県を入力してください")
       end
       it 'prefecture_idが1だと登録できない' do
         @item_purchase.prefecture_id = 1
         @item_purchase.valid?
-        expect(@item_purchase.errors.full_messages).to include("Prefectureは1以外の値にしてください")
+        expect(@item_purchase.errors.full_messages).to include("都道府県は1以外の値にしてください")
       end
       it 'cityが空だと登録できない' do
         @item_purchase.city = nil
         @item_purchase.valid?
-        expect(@item_purchase.errors.full_messages).to include("Cityを入力してください")
+        expect(@item_purchase.errors.full_messages).to include("市区町村を入力してください")
       end
       it 'house_numberが空だと登録できない' do
         @item_purchase.house_number = nil
         @item_purchase.valid?
-        expect(@item_purchase.errors.full_messages).to include("House numberを入力してください")
+        expect(@item_purchase.errors.full_messages).to include("番地を入力してください")
       end
       it 'phone_numberが空だと登録できない' do
         @item_purchase.phone_number = nil
         @item_purchase.valid?
-        expect(@item_purchase.errors.full_messages).to include("Phone numberを入力してください")
+        expect(@item_purchase.errors.full_messages).to include("電話番号を入力してください")
       end
       it 'phone_numberが12桁だと登録できない' do
         @item_purchase.phone_number = 123456789123
         @item_purchase.valid?
-        expect(@item_purchase.errors.full_messages).to include("Phone numberが間違っています")
+        expect(@item_purchase.errors.full_messages).to include("電話番号が間違っています")
       end
     end
 


### PR DESCRIPTION
WHAT：エラーを日本語化する機能の実装
WHY：エラーが英語だと利用者がわかりにくいと感じるため